### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 [![Build Status](https://travis-ci.org/lextoumbourou/simple-ranker.svg?branch=master)](https://travis-ci.org/lextoumbourou/simple-ranker)
 [![Coverage Status](https://coveralls.io/repos/lextoumbourou/simple-ranker/badge.png)](https://coveralls.io/r/lextoumbourou/simple-ranker)
 [![Code Health](https://landscape.io/github/lextoumbourou/simple-ranker/master/landscape.png)](https://landscape.io/github/lextoumbourou/simple-ranker/master)
-[![License](https://pypip.in/license/simple-ranker/badge.png)](https://pypi.python.org/pypi/simple-ranker)
-[![Latest Version](https://pypip.in/version/simple-ranker/badge.png)](https://pypi.python.org/pypi/simple-ranker)
-[![Downloads](https://pypip.in/download/simple-ranker/badge.png)](https://pypi.python.org/pypi/simple-ranker)
+[![License](https://img.shields.io/pypi/l/simple-ranker.svg)](https://pypi.python.org/pypi/simple-ranker)
+[![Latest Version](https://img.shields.io/pypi/v/simple-ranker.svg)](https://pypi.python.org/pypi/simple-ranker)
+[![Downloads](https://img.shields.io/pypi/dm/simple-ranker.svg)](https://pypi.python.org/pypi/simple-ranker)
 
 *An extremely simple, multi-value ranking module for [pandas](http://pandas.pydata.org) DataFrames.*
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20simple-ranker))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `simple-ranker`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.